### PR TITLE
feat(permissions): allow organization_projects for Projects V2 writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Available permissions:
 - discussions
 - pages
 - workflows
+- organization_projects (organization-level; for Projects V2 GraphQL writes)
 
 Access levels:
 - read

--- a/packages/server/permissions.js
+++ b/packages/server/permissions.js
@@ -22,7 +22,10 @@ const VALID_PERMISSIONS = [
   'checks',
   'discussions',
   'pages',
-  'workflows'
+  'workflows',
+  // Organization-level permission — required for Projects V2 GraphQL
+  // mutations (e.g. updating fields on an org ProjectV2 board).
+  'organization_projects'
 ];
 
 async function validatePermissions(permissions) {


### PR DESCRIPTION
## Why

Writing to an **organization ProjectV2 board** via the GraphQL API (e.g. `updateProjectV2ItemFieldValue`) needs an installation token carrying the org-level **`organization_projects: write`** scope. The default `GITHUB_TOKEN` cannot do this, so a token-bureau App token is the natural fit.

But today the server rejects it: `packages/server/permissions.js` hard-codes `VALID_PERMISSIONS` **without** `organization_projects`, so `validatePermissions()` throws `Invalid permission: organization_projects` — both when the key appears in the server config and when a workflow requests it.

## What

- `packages/server/permissions.js` — add `organization_projects` to `VALID_PERMISSIONS`.
- `README.md` — list it under *Available permissions* (flagged as organization-level).

**Additive & backward-compatible**: existing configs and requests are unaffected. The permission only takes effect where it is explicitly granted in the server permissions config, and — as with any scope — requires the backing GitHub App to hold *Organization projects: Read and write*.

## Context

Needed by `SocialGouv/egapro` to stamp Start/End date columns on its project board from a merge workflow. Rollout sequence on the consumer side once this ships: (1) grant the token-bureau App the *Organization projects* permission, (2) add `organization_projects: write` to the repo's whitelist in `SocialGouv/infra-apps`, (3) the workflow requests the scope.
