### PR TITLE
fix(ci): release on push to main with app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,34 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write
 
 jobs:
   release:
-    if:  github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release)')
     runs-on: ubuntu-latest
     steps:
+      # GITHUB_TOKEN is read-only on fork PRs and its pushes don't trigger
+      # workflows (the tag would never build a docker image) — use an app
+      # token minted by token-bureau itself.
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -42,8 +53,6 @@ jobs:
       - name: Create Release
         run: |
           pnpm release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes
         run: |


### PR DESCRIPTION
## Problème

Le job release de la PR #6 a échoué au `git push` : `Permission to SocialGouv/token-bureau.git denied to github-actions[bot]` ([run](https://github.com/SocialGouv/token-bureau/actions/runs/29959467819/job/89056730348)).

Cause : le workflow se déclenche sur `pull_request: closed`, et la PR #6 venait d'un fork — sur un event `pull_request` issu d'un fork, le `GITHUB_TOKEN` est en lecture seule quel que soit le bloc `permissions:`.

## Fix

- Trigger sur `push: branches: [main]` (+ `workflow_dispatch`), comme les autres repos SocialGouv — le workflow tourne alors dans le contexte du repo de base.
- Push avec un token d'App minté par token-bureau lui-même (dogfooding, pattern matomo-postgres) : un push fait avec `GITHUB_TOKEN` ne déclenche jamais de workflow, donc le tag de release ne buildait pas d'image docker versionnée. Avec le token d'App, le push du tag `v*` déclenche bien le workflow docker.
- Garde anti-boucle : skip si le head commit est `chore(release): …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)